### PR TITLE
add ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install h5py numpy
+      - name: Run test
+        run: |
+          python functional_test.py


### PR DESCRIPTION
Hello, maintainer.
I've implemented CI for this repository. This will allow us to run tests on the cloud environment every time a pull request is created, which will improve the maintainability of the code

If the maintainer merges this, the CI will work.
For your reference, here is the result of a CI run on the repository I forked.

## Result

> https://github.com/kazukazuinaina/bd5lint/actions/runs/464017998